### PR TITLE
Add banners table and implement /banners endpoint in webserver

### DIFF
--- a/features/webserver/webserver.py
+++ b/features/webserver/webserver.py
@@ -148,6 +148,47 @@ class Webserver(Cog):
             }
         )
 
+    @route("/banners/{user_id}")
+    async def banners(self: "Webserver", request: Request) -> Response:
+        """
+        Selects banners from the database for /history endpoint.
+        """
+
+        try:
+            user_id = int(request.match_info["user_id"])
+        except ValueError:
+            return json_response({"error": "Invalid user ID."}, status=400)
+
+        user = self.bot.get_user(user_id)
+        banners: List[Dict[str, str | datetime]] = await self.bot.db.fetch(
+            """
+            SELECT banner, updated_at
+            FROM metrics.banners
+            WHERE user_id = $1
+            ORDER BY updated_at DESC
+            """,
+            user_id,
+        )
+
+        return json_response(
+            {
+                "user": {
+                    "id": user_id,
+                    "name": user.name,
+                    "banner": user.banner.url if user and user.banner else None,
+                }
+                if user
+                else None,
+                "banners": [
+                    {
+                        "banner": banner["banner"],
+                        "updated_at": banner["updated_at"].timestamp(),
+                    }
+                    for banner in banners
+                ],
+            }
+        )
+
     @route("/commands")
     async def commands(self: "Webserver", request: Request) -> Response:
         """Returns information about all registered commands."""

--- a/tools/schema/tables.sql
+++ b/tools/schema/tables.sql
@@ -352,6 +352,13 @@ CREATE TABLE IF NOT EXISTS metrics.avatars (
     PRIMARY KEY (user_id, avatar)
 );
 
+CREATE TABLE IF NOT EXISTS metrics.banners (
+    user_id BIGINT NOT NULL,
+    banner TEXT NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, banner)
+);
+
 --- GitHub
 CREATE TABLE IF NOT EXISTS github_watches (
     guild_id BIGINT,


### PR DESCRIPTION
Created a new 'banners' table in the metrics schema to store user banners. Implemented the /banners endpoint in the webserver to fetch and return banners associated with a user ID, including error handling for invalid user IDs.